### PR TITLE
Fix URL in overview.ipynb

### DIFF
--- a/docs/overview.ipynb
+++ b/docs/overview.ipynb
@@ -12,7 +12,7 @@
         "\n",
         "It handles downloading and preparing the data deterministically and constructing a `tf.data.Dataset` (or `np.array`).\n",
         "\n",
-        "Note: Do not confuse [TFDS](https://www.tensorflow.org/datasets) (this library) with `tf.data` (TensorFlow API to build efficient data pipelines). TFDS is a high level wrapper around `tf.data`. If you're not familiar with this API, we encourage you to read [the official tf.data guide](https://www.tensorflow.org/guide/datasets) first.\n"
+        "Note: Do not confuse [TFDS](https://www.tensorflow.org/datasets) (this library) with `tf.data` (TensorFlow API to build efficient data pipelines). TFDS is a high level wrapper around `tf.data`. If you're not familiar with this API, we encourage you to read [the official tf.data guide](https://www.tensorflow.org/guide/data) first.\n"
       ]
     },
     {


### PR DESCRIPTION
Fixed a link `tensorflow.org/guide/datasets` -> `tensorflow.org/guide/data`.